### PR TITLE
fix(deps): adds missing @types/node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@types/jest": "^27.0.3",
         "@types/jsonpath": "^0.2.0",
+        "@types/node": "^16.11.9",
         "@types/node-fetch": "^2.5.10",
         "@types/yargs": "^17.0.7",
         "jest": "^27.3.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@types/jest": "^27.0.3",
     "@types/jsonpath": "^0.2.0",
+    "@types/node": "^16.11.9",
     "@types/node-fetch": "^2.5.10",
     "@types/yargs": "^17.0.7",
     "jest": "^27.3.1",


### PR DESCRIPTION
Without it, TypeScript cannot infer the types from e.g. `process`:
https://github.com/eficode/tscli/blob/680d0c5baef7e1e0462fab1e24dd628325c8705b/cli.ts#L7