### PR TITLE
refactor: adds typescript types to phases and worktimes, and rework iteration logic

### DIFF
--- a/src/phases.ts
+++ b/src/phases.ts
@@ -1,53 +1,76 @@
+import assert from 'assert';
 import { printTable } from 'console-table-printer';
 
 import { get } from './api';
 
-export const findPhases = async (id: number) => {
+export interface Phase {
+  id: number;
+  name: string;
+  projectName: string;
+}
+
+/**
+ * Checks whether an input adheres to the type `Phase`
+ * @param phase The input to be validated whether it is of type `Phase`
+ * @returns True when the input is a valid instance of Phase, else false.
+ */
+export const isPhase = (phase: any): phase is Phase =>
+  typeof phase === 'object' &&
+  typeof phase.id === 'number' &&
+  typeof phase.name === 'string' &&
+  typeof phase.projectName === 'string';
+
+/**
+ * Retrieves all phases from a list of projects.
+ * @param projects The projects input where to retrieve the phases from
+ * @returns All phases in a project
+ */
+const projectsToPhases = (projects: any[]): Phase[] =>
+  projects.flatMap((project) => {
+    const projectPhases = project.phases;
+
+    // Validate that the project contains an array of phases
+    assert(Array.isArray(projectPhases));
+
+    return (
+      projectPhases
+        // Transform each phase input into an object of type Phase
+        .map((phase) => ({ id: phase.id, name: phase.name, projectName: project.name }))
+        // Make sure that all phases we just created are valid instances of Phase
+        .map((phase) => {
+          assert(isPhase(phase));
+
+          return phase;
+        })
+    );
+  });
+
+export const findPhases = async (id: number): Promise<Phase[] | null> => {
   const projects = await get('projects?active=true&userHasAccess=true');
 
-  const phases = projects
-    .map((project: any) => {
-      const filteredPhases = project.phases.filter((phase: any) => id === phase.id);
+  assert(Array.isArray(projects), 'Expected projects to be an array');
 
-      if (filteredPhases) {
-        return filteredPhases.map((phase: any) => ({ id: phase.id, name: phase.name, projectName: project.name }));
-      }
+  const phases = projectsToPhases(projects);
 
-      return null;
-    })
-    .filter((x: any) => x)
-    .flat();
-
-  return phases;
+  return phases.filter((phase) => phase.id === id);
 };
 
-export const getCurrentPhases = async () => {
+export const getCurrentPhases = async (): Promise<Phase[]> => {
   const projects = await get('projects?active=true&userHasAccess=true');
-  const favorites: any = await get('preferences/favoritePhases');
+  const favorites = await get('preferences/favoritePhases');
 
-  const currentPhases = projects
-    .map((project: any) => {
-      const phases = project.phases
-        .map((phase: any) => (favorites.favoritePhases.includes(phase.id) ? phase : null))
-        .filter((x: any) => x);
+  assert(Array.isArray(projects), 'Expected projects to be an array');
 
-      if (phases) {
-        return phases.map((phase: any) => ({ id: phase.id, name: phase.name, projectName: project.name }));
-      }
+  const phases = projectsToPhases(projects);
 
-      return null;
-    })
-    .filter((x: any) => x)
-    .flat();
-
-  return currentPhases;
+  return phases.filter((phase) => favorites.favoritePhases.includes(phase.id));
 };
 
-export const getPhaseIds = (phases: any) => {
-  return phases.map((phase: any) => phase.id);
+export const getPhaseIds = (phases: Phase[]): (number | undefined)[] => {
+  return phases.map((phase) => phase.id);
 };
 
-export const listPhases = async () => {
+export const listPhases = async (): Promise<void> => {
   const phases = await getCurrentPhases();
 
   printTable(

--- a/src/worktimes.ts
+++ b/src/worktimes.ts
@@ -6,43 +6,73 @@ import jsonpath from 'jsonpath';
 import { printTable } from 'console-table-printer';
 
 import { get, post, put } from './api';
-import { getCurrentPhases } from './phases';
+import { getCurrentPhases, Phase } from './phases';
 import { getWeekdays } from './utils';
 
-const getWorktimes = async (dt?: string) => {
+export interface Worktime {
+  id: number;
+  phaseId: number;
+  taskId: number;
+  date: string;
+  duration?: number;
+  description?: string;
+}
+
+/**
+ * Verifies whether its input is of type `Worktime`.
+ */
+export const isWorktime = (worktime: any): worktime is Worktime =>
+  typeof worktime === 'object' &&
+  typeof worktime?.id === 'number' &&
+  typeof worktime?.phaseId === 'number' &&
+  typeof worktime?.taskId === 'number' &&
+  typeof worktime?.date === 'string' &&
+  (worktime?.duration === undefined || typeof worktime?.duration === 'number') &&
+  (worktime?.description === undefined || typeof worktime?.description === 'string');
+
+const getWorktimes = async (dt?: string): Promise<Worktime[]> => {
+  // Extend DayJS
   dayjs.extend(isoWeek);
 
   const date = dayjs(dt);
 
   const weekly = await get(`worktimes/weekly?year=${date.format('YYYY')}&week=${date.isoWeek()}`);
 
-  return weekly.worktimes.map((w: any) => ({
-    id: w.id,
-    phaseId: w.task.phaseId,
-    taskId: w.taskId,
-    date: w.date,
-    duration: w.duration,
-  }));
+  return weekly.worktimes.map((w: any) => {
+    // Map the input into a Worktime object
+    const worktime = {
+      id: w.id,
+      phaseId: w.task.phaseId,
+      taskId: w.taskId,
+      date: w.date,
+      duration: w.duration || undefined,
+      description: w.description || undefined,
+    };
+
+    // Assert that we indeed created a valid Worktime instance.
+    if (!isWorktime(worktime)) {
+      throw new Error(`Received invalid worktime ${JSON.stringify(worktime)}`);
+    }
+
+    return worktime;
+  });
 };
 
-const getPhasesForDays = (phases: any, worktimes: any) => {
+const getPhasesForDays = (phases: Phase[], worktimes: Worktime[]): { [columnName: string]: string | number }[] => {
   const weekdays = getWeekdays();
 
-  const phasesForDays = phases.map((phase: any) => {
-    const phaseWeek: { [name: string]: string } = {
-      Name: phase.projectName === phase.name ? phase.name : `${phase.projectName} (${phase.name})`,
-      Id: phase.id,
-    };
-    weekdays.forEach((day) => {
-      const worktime = worktimes.find((w: any) => w.date === day.date && w.phaseId === phase.id);
-      if (worktime) {
-        phaseWeek[day.name] = worktime.duration || 0;
-      } else {
-        phaseWeek[day.name] = '';
-      }
-    });
-    return phaseWeek;
-  });
+  const phasesForDays = phases.map((phase) => ({
+    Name: phase.projectName === phase.name ? phase.name : `${phase.projectName} (${phase.name})`,
+    Id: phase.id,
+    // Add a column for each day of the week containing the worktime duration
+    ...Object.fromEntries(
+      weekdays.map((day) => {
+        const worktime = worktimes.find((w: any) => w.date === day.date && w.phaseId === phase.id);
+
+        return [day.name, worktime ? worktime.duration || 0 : ''];
+      }),
+    ),
+  }));
 
   return phasesForDays;
 };
@@ -66,7 +96,7 @@ export const listWeek = async () => {
     const worktimes = await getWorktimes();
     const phases = await getCurrentPhases();
 
-    const phasesForDays = await getPhasesForDays(phases, worktimes);
+    const phasesForDays = getPhasesForDays(phases, worktimes);
 
     printTable(phasesForDays);
   } catch (err) {
@@ -81,7 +111,7 @@ export const createWorktime = async (argv: any) => {
 
   const worktimes = await getWorktimes(argv.date);
 
-  const worktime = worktimes.find((w: any) => w.date === date && w.phaseId === argv.id);
+  const worktime = worktimes.find((w) => w.date === date && w.phaseId === argv.id);
 
   if (!date || !task.id) {
     console.log('Creating worktime failed. Please check your parameters.');

--- a/test/phases.test.ts
+++ b/test/phases.test.ts
@@ -1,7 +1,7 @@
 import { mocked } from 'ts-jest/utils';
 import { get } from '../src/api';
 
-import { findPhases, getCurrentPhases } from '../src/phases';
+import { findPhases, getCurrentPhases, isPhase, Phase } from '../src/phases';
 
 import * as testData from './data/phases.json';
 
@@ -47,4 +47,109 @@ describe('Phases', () => {
       expect(await getCurrentPhases()).toStrictEqual(currentPhases);
     });
   });
+
+  describe('isPhase', () => {
+    it('should accept a valid Phase object', () => {
+      // Arrange
+      const phase: Phase = {
+        id: 1,
+        name: "Phase name",
+        projectName: "Project name",
+      }
+
+      // Act
+      const isCorrectPhase = isPhase(phase)
+
+      // Assert
+      expect(isCorrectPhase).toBe(true)
+    })
+
+    it('should reject Phase objects missing the id-field', () => {
+      // Arrange
+      const phase: Omit<Phase, "id"> = {
+        name: "Phase name",
+        projectName: "Project name",
+      }
+
+      // Act
+      const isCorrectPhase = isPhase(phase)
+
+      // Assert
+      expect(isCorrectPhase).toBe(false)
+    })
+
+    it('should reject Phase objects missing the name-field', () => {
+      // Arrange
+      const phase: Omit<Phase, "name"> = {
+        id: 1,
+        projectName: "Project name",
+      }
+
+      // Act
+      const isCorrectPhase = isPhase(phase)
+
+      // Assert
+      expect(isCorrectPhase).toBe(false)
+    })
+
+    it('should reject Phase objects missing the projectName-field', () => {
+      // Arrange
+      const phase: Omit<Phase, "projectName"> = {
+        id: 1,
+        name: "Phase name",
+      }
+
+      // Act
+      const isCorrectPhase = isPhase(phase)
+
+      // Assert
+      expect(isCorrectPhase).toBe(false)
+    })
+
+    it('should reject Phase objects with not a number as the id', () => {
+      // Arrange
+      const phase: Omit<Phase, "id"> & {id: any} = {
+        id: "1",
+        name: "Phase name",
+        projectName: "Project name",
+      }
+
+      // Act
+      const isCorrectPhase = isPhase(phase)
+
+      // Assert
+      expect(isCorrectPhase).toBe(false)
+    })
+
+    it('should reject Phase objects with not a string as the name', () => {
+      // Arrange
+      const phase: Omit<Phase, "name"> & {name: any} = {
+        id: 1,
+        name: {},
+        projectName: "Project name",
+      }
+
+      // Act
+      const isCorrectPhase = isPhase(phase)
+
+      // Assert
+      expect(isCorrectPhase).toBe(false)
+    })
+
+
+    it('should reject Phase objects with not a string as the projectName', () => {
+      // Arrange
+      const phase: Omit<Phase, "projectName"> & {projectName: any} = {
+        id: 1,
+        name: "Name",
+        projectName: null,
+      }
+
+      // Act
+      const isCorrectPhase = isPhase(phase)
+
+      // Assert
+      expect(isCorrectPhase).toBe(false)
+    })
+  })
 });

--- a/test/worktimes.test.ts
+++ b/test/worktimes.test.ts
@@ -1,7 +1,7 @@
 import { mocked } from 'ts-jest/utils';
 import { get } from '../src/api';
 
-import { getDefaultTaskFor } from '../src/worktimes';
+import { getDefaultTaskFor, isWorktime, Worktime } from '../src/worktimes';
 
 import * as testData from './data/phases.json';
 
@@ -22,6 +22,141 @@ describe('Worktimes', () => {
       const task = { id: 12306, name: 'No task', phaseId: 3448 };
 
       expect(await getDefaultTaskFor('3870')).toStrictEqual(task);
+    });
+  });
+
+  describe('isWorktime', () => {
+    it('should accept a valid Worktime object', () => {
+      // Arrange
+      const phase: Worktime = {
+        id: 1,
+        phaseId: 2,
+        taskId: 3,
+        date: '2021-11-19',
+        duration: 4,
+        description: 'My description',
+      };
+
+      // Act
+      const isValid = isWorktime(phase);
+
+      // Assert
+      expect(isValid).toBe(true);
+    });
+
+    it('should accept a Worktime object without a description', () => {
+      // Arrange
+      const phase: Worktime = {
+        id: 1,
+        phaseId: 2,
+        taskId: 3,
+        date: '2021-11-19',
+        duration: 4,
+      };
+
+      // Act
+      const isValid = isWorktime(phase);
+
+      // Assert
+      expect(isValid).toBe(true);
+    });
+
+    it('should reject Worktime objects missing the id field', () => {
+      // Arrange
+      const phase: Omit<Worktime, 'id'> = {
+        phaseId: 2,
+        taskId: 3,
+        date: '2021-11-19',
+        duration: 4,
+      };
+
+      // Act
+      const isValid = isWorktime(phase);
+
+      // Assert
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject Worktime objects missing the phaseId field', () => {
+      // Arrange
+      const phase: Omit<Worktime, 'phaseId'> = {
+        id: 1,
+        taskId: 3,
+        date: '2021-11-19',
+        duration: 4,
+      };
+
+      // Act
+      const isValid = isWorktime(phase);
+
+      // Assert
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject Worktime objects missing the taskId field', () => {
+      // Arrange
+      const phase: Omit<Worktime, 'taskId'> = {
+        id: 1,
+        phaseId: 2,
+        date: '2021-11-19',
+        duration: 4,
+      };
+
+      // Act
+      const isValid = isWorktime(phase);
+
+      // Assert
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject Worktime objects missing the date field', () => {
+      // Arrange
+      const phase: Omit<Worktime, 'date'> = {
+        id: 1,
+        phaseId: 2,
+        taskId: 3,
+        duration: 4,
+      };
+
+      // Act
+      const isValid = isWorktime(phase);
+
+      // Assert
+      expect(isValid).toBe(false);
+    });
+
+    it('should accept Worktime objects missing the duration field', () => {
+      // Arrange
+      const phase: Omit<Worktime, 'duration'> = {
+        id: 1,
+        phaseId: 2,
+        taskId: 3,
+        date: '2021-11-19',
+      };
+
+      // Act
+      const isValid = isWorktime(phase);
+
+      // Assert
+      expect(isValid).toBe(true);
+    });
+
+    it('should reject Worktime objects with null for the description', () => {
+      // Arrange
+      const phase: Omit<Worktime, 'description'> & { description: any } = {
+        id: 1,
+        phaseId: 2,
+        taskId: 3,
+        date: '2021-11-19',
+        duration: 4,
+        description: null,
+      };
+
+      // Act
+      const isValid = isWorktime(phase);
+
+      // Assert
+      expect(isValid).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Adds TypeScript types to `src/phases.ts` and `src/worktimes.ts`, to make development slightly easier.

These changes include logic which validates the types at runtime when converting the API responses into the internal Phase and Worktime-types. Which means that the application will panic and error out when the type of the response received from the API doesn't match the type it expects.

In addition, here and there the iteration logic is reworked to have a lower level of nesting, which yields code which is simpler and easier to reason about.