### PR TITLE
ci(dependabot): enables automatic dependency upgrade PRs by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    labels:
+      - 'Github Actions'
+      - 'dependencies'
+
+  # Maintain dependencies for yarn
+  - package-ecosystem: 'npm' # We need to specify npm, although we use yarn, see https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    versioning-strategy: 'increase'
+    labels:
+      - 'yarn'
+      - 'dependencies'
+    ignore:
+      # Ignore any newer version of Node types, since we currently only target 16.
+      - dependency-name: "@types/node"
+        versions: [">=17"]


### PR DESCRIPTION
_Note: I haven't created the labels yet, those need to be added manually or otherwise Dependabot is likely to complain about them missing. Didn't want to get ahead of myself and do it already before the PR is reviewed._